### PR TITLE
Fix right side of order's nil-coalescing operator for patch request

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ The failing test is trying to `PATCH` a specific ToDo item. A `PATCH` request up
     func updateHandler(id: Int, new: ToDo, completion: (ToDo?, RequestError?) -> Void ) -> Void {
         var current = todoStore[id]
         current.user = new.user ?? current.user
-        current.order = new.order ?? new.order
+        current.order = new.order ?? current.order
         current.title = new.title ?? current.title
         current.completed = new.completed ?? current.completed
         execute {


### PR DESCRIPTION
When new.order is nil we should fall back to current.order.