### PR TITLE
Update to use Kitura-CORS 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ By default, web servers only serve content to web pages that were served by that
 
    Add the following to the end of the dependencies section of the Package.swift file:
    ```
-      .package(url: "https://github.com/IBM-Swift/Kitura-CORS", .upToNextMinor(from: "2.0.0")),
+      .package(url: "https://github.com/IBM-Swift/Kitura-CORS", .upToNextMinor(from: "2.1.0")),
    ```
    and update the dependencies line for the Application target to the following:
    ```


### PR DESCRIPTION
Using `kitura init` now generates Kitura 2.1.x code, which has a dependency conflict with the Kitura-CORS 2.0.0 middleware the tutorial asks you to include.

Kitura-CORS has been updated in 2.1 to work with any version of Kitura 2.x, so updating the tutorial to use it.