### PR TITLE
Version pinning

### DIFF
--- a/DeployingToKube.md
+++ b/DeployingToKube.md
@@ -64,7 +64,7 @@ We can now create a PostgreSQL release called `postgresql-database`.
 **Note**: Kubernetes and Helm are very specific on names, and calling your database anything else will result in later parts of the tutorial requiring tweaking.
 
 ```bash
-helm install --name postgresql-database --set postgresDatabase=tododb stable/postgresql
+helm install --name postgresql-database --set postgresDatabase=tododb stable/postgresql --version 0.17.0
 ```
 
 *The `--set` flag tells Helm to set some values during the `install` process. For PostgreSQL, we can specify a database we want created. We call that database `tododb` to match the name already in our Swift code from the last tutorial.*

--- a/MonitoringKube.md
+++ b/MonitoringKube.md
@@ -40,7 +40,7 @@ Whilst Prometheus provides the ability to build simple graphs and alerts, Grafan
 Installing Grafana into Kubernetes can be done using its provided Helm chart:
 
 ```sh
-helm install stable/grafana --set adminPassword=PASSWORD --name grafana --namespace grafana
+helm install stable/grafana --set adminPassword=PASSWORD --name grafana --namespace grafana --version 1.14.3
 ```
 
 You can then run the following two commands in order to be able to connect to Grafana from your browser:


### PR DESCRIPTION
Due to unpredictable changes, I have pinned the helm chart versions for PostgreSQL and Grafana to the following:

PostgreSQL: **0.17.0**
Grafana: **1.14.3**